### PR TITLE
Add API endpoint to upload bookmark preview images

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -26,7 +26,14 @@ from bookmarks.models import (
     User,
     BookmarkBundle,
 )
-from bookmarks.services import assets, bookmarks, bundles, auto_tagging, website_loader
+from bookmarks.services import (
+    assets,
+    bookmarks,
+    bundles,
+    auto_tagging,
+    preview_image_loader,
+    website_loader,
+)
 from bookmarks.utils import normalize_url
 from bookmarks.type_defs import HttpRequest
 from bookmarks.views import access
@@ -103,6 +110,70 @@ class BookmarkViewSet(
         bookmark = self.get_object()
         bookmarks.unarchive_bookmark(bookmark)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=["post"], detail=True, url_path="preview-image")
+    def upload_preview_image(self, request: HttpRequest, pk):
+        bookmark = self.get_object()
+
+        upload_file = request.FILES.get("file")
+        if not upload_file:
+            return Response(
+                {"error": "No file provided."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            new_preview_image_file = preview_image_loader.save_uploaded_preview_image(
+                upload_file
+            )
+        except preview_image_loader.PreviewImageUploadError as error:
+            return Response(
+                {"error": str(error)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception as error:
+            logger.error(
+                "Failed to upload preview image. bookmark_id=%s",
+                bookmark.id,
+                exc_info=error,
+            )
+            return Response(
+                {"error": "Failed to upload preview image."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        old_preview_image_file = bookmark.preview_image_file
+        bookmark.preview_image_file = new_preview_image_file
+        bookmark.save(update_fields=["preview_image_file"])
+
+        if (
+            old_preview_image_file
+            and old_preview_image_file != new_preview_image_file
+        ):
+            old_preview_image_path = os.path.join(
+                settings.LD_PREVIEW_FOLDER, old_preview_image_file
+            )
+            try:
+                if os.path.exists(old_preview_image_path):
+                    os.remove(old_preview_image_path)
+            except Exception as error:
+                logger.error(
+                    "Failed to delete previous preview image. bookmark_id=%s file=%s",
+                    bookmark.id,
+                    old_preview_image_file,
+                    exc_info=error,
+                )
+
+        serializer = self.get_serializer(bookmark)
+        preview_image_url = serializer.data.get("preview_image_url")
+
+        return Response(
+            {
+                "message": "Preview image uploaded successfully.",
+                "preview_image_url": preview_image_url,
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
     @action(methods=["get"], detail=False)
     def check(self, request: HttpRequest):

--- a/bookmarks/tests/test_bookmarks_api.py
+++ b/bookmarks/tests/test_bookmarks_api.py
@@ -1,10 +1,14 @@
 import datetime
 import io
+import os
+import shutil
+import tempfile
 import urllib.parse
 from collections import OrderedDict
 from unittest.mock import patch, ANY
 
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -1268,6 +1272,121 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
         response = self.get(url, expected_status_code=status.HTTP_200_OK)
 
         self.assertUserProfile(response, profile)
+
+    def test_upload_preview_image(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            upload = SimpleUploadedFile(
+                "preview.png", b"test-image", content_type="image/png"
+            )
+            response = self.client.post(
+                reverse("linkding:bookmark-upload-preview-image", args=[bookmark.id]),
+                {"file": upload},
+                format="multipart",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data["message"], "Preview image uploaded successfully."
+        )
+
+        bookmark.refresh_from_db()
+        self.assertTrue(bookmark.preview_image_file.endswith(".png"))
+
+        preview_path = os.path.join(temp_dir, bookmark.preview_image_file)
+        self.assertTrue(os.path.exists(preview_path))
+        self.assertEqual(
+            response.data["preview_image_url"],
+            f"http://testserver/static/{bookmark.preview_image_file}",
+        )
+
+    def test_upload_preview_image_replaces_previous_file(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            bookmark.preview_image_file = "existing.png"
+            bookmark.save(update_fields=["preview_image_file"])
+            old_path = os.path.join(temp_dir, "existing.png")
+            with open(old_path, "wb") as file:
+                file.write(b"old")
+
+            upload = SimpleUploadedFile(
+                "preview.jpg", b"new-image", content_type="image/jpeg"
+            )
+            response = self.client.post(
+                reverse("linkding:bookmark-upload-preview-image", args=[bookmark.id]),
+                {"file": upload},
+                format="multipart",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        bookmark.refresh_from_db()
+        new_path = os.path.join(temp_dir, bookmark.preview_image_file)
+        self.assertTrue(os.path.exists(new_path))
+        self.assertFalse(os.path.exists(old_path))
+
+    def test_upload_preview_image_requires_file(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            response = self.client.post(
+                reverse("linkding:bookmark-upload-preview-image", args=[bookmark.id]),
+                {},
+                format="multipart",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "No file provided.")
+
+    def test_upload_preview_image_rejects_large_files(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir, LD_PREVIEW_MAX_SIZE=5):
+            upload = SimpleUploadedFile(
+                "preview.png", b"123456", content_type="image/png"
+            )
+            response = self.client.post(
+                reverse("linkding:bookmark-upload-preview-image", args=[bookmark.id]),
+                {"file": upload},
+                format="multipart",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "File exceeds maximum size.")
+        self.assertEqual(os.listdir(temp_dir), [])
+
+    def test_upload_preview_image_rejects_invalid_file_type(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            upload = SimpleUploadedFile(
+                "preview.txt", b"not-an-image", content_type="text/plain"
+            )
+            response = self.client.post(
+                reverse("linkding:bookmark-upload-preview-image", args=[bookmark.id]),
+                {"file": upload},
+                format="multipart",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "Unsupported file type.")
 
     def create_singlefile_upload_body(self):
         url = "https://example.com"

--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -212,6 +212,37 @@ DELETE /api/bookmarks/<id>/
 
 Deletes a bookmark by ID.
 
+**Upload preview image**
+
+```
+POST /api/bookmarks/<id>/preview-image/
+```
+
+Uploads a custom preview image for a bookmark. Send a `multipart/form-data`
+request with a `file` field that contains the image to upload. The file must
+use one of the supported preview image extensions and stay within the configured
+maximum size (see the `LD_PREVIEW_ALLOWED_EXTENSIONS` and
+`LD_PREVIEW_MAX_SIZE` settings).
+
+Example request using `curl`:
+
+```
+curl \
+  -X POST \
+  -H "Authorization: Token <Token>" \
+  -F "file=@/path/to/preview.png" \
+  http://127.0.0.1:8000/api/bookmarks/1/preview-image/
+```
+
+Example response:
+
+```json
+{
+  "message": "Preview image uploaded successfully.",
+  "preview_image_url": "http://127.0.0.1:8000/static/0ac5c53db923727765216a3a58e70522.png"
+}
+```
+
 ### Bookmark Assets
 
 **List**


### PR DESCRIPTION
## Summary
- add a REST action for uploading custom preview images to bookmarks
- validate uploaded preview files before storing them and document the workflow
- cover the new behaviour with API and permission tests

## Testing
- uv run pytest bookmarks/tests/test_bookmarks_api.py bookmarks/tests/test_bookmarks_api_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0515ca3083309902f8b4595d873e