### PR TITLE
Allow uploading preview image when creating bookmark

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,10 +39,10 @@ jobs:
           file: ./docker/default.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            sissbruecker/linkding:latest
-            sissbruecker/linkding:${{ env.VERSION }}
-            ghcr.io/sissbruecker/linkding:latest
-            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}
+            naimdaniel2591/linkding:latest
+            naimdaniel2591/linkding:${{ env.VERSION }}
+            ghcr.io/naimdaniel2591/linkding:latest
+            ghcr.io/naimdaniel2591/linkding:${{ env.VERSION }}
           target: linkding
           push: true
 
@@ -53,10 +53,10 @@ jobs:
           file: ./docker/alpine.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            sissbruecker/linkding:latest-alpine
-            sissbruecker/linkding:${{ env.VERSION }}-alpine
-            ghcr.io/sissbruecker/linkding:latest-alpine
-            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-alpine
+            naimdaniel2591/linkding:latest-alpine
+            naimdaniel2591/linkding:${{ env.VERSION }}-alpine
+            ghcr.io/naimdaniel2591/linkding:latest-alpine
+            ghcr.io/naimdaniel2591/linkding:${{ env.VERSION }}-alpine
           target: linkding
           push: true
 
@@ -67,10 +67,10 @@ jobs:
           file: ./docker/default.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            sissbruecker/linkding:latest-plus
-            sissbruecker/linkding:${{ env.VERSION }}-plus
-            ghcr.io/sissbruecker/linkding:latest-plus
-            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-plus
+            naimdaniel2591/linkding:latest-plus
+            naimdaniel2591/linkding:${{ env.VERSION }}-plus
+            ghcr.io/naimdaniel2591/linkding:latest-plus
+            ghcr.io/naimdaniel2591/linkding:${{ env.VERSION }}-plus
           target: linkding-plus
           push: true
 
@@ -81,9 +81,9 @@ jobs:
           file: ./docker/alpine.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            sissbruecker/linkding:latest-plus-alpine
-            sissbruecker/linkding:${{ env.VERSION }}-plus-alpine
-            ghcr.io/sissbruecker/linkding:latest-plus-alpine
-            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-plus-alpine
+            naimdaniel2591/linkding:latest-plus-alpine
+            naimdaniel2591/linkding:${{ env.VERSION }}-plus-alpine
+            ghcr.io/naimdaniel2591/linkding:latest-plus-alpine
+            ghcr.io/naimdaniel2591/linkding:${{ env.VERSION }}-plus-alpine
           target: linkding-plus
           push: true

--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -141,6 +141,12 @@ the future to return an error instead.
 If the title and description are not provided or empty, the application automatically tries to scrape them from the
 bookmarked website. This behavior can be disabled by adding the `disable_scraping` query parameter to the API request.
 
+To upload a custom preview image during creation, send the request as
+`multipart/form-data` and include a `preview_image` file field alongside the other
+bookmark attributes. The uploaded file must use one of the supported preview
+image extensions and stay within the configured maximum size (see the
+`LD_PREVIEW_ALLOWED_EXTENSIONS` and `LD_PREVIEW_MAX_SIZE` settings).
+
 Example payload:
 
 ```json
@@ -157,6 +163,17 @@ Example payload:
     "tag2"
   ]
 }
+```
+
+Example request with a preview image using `curl`:
+
+```
+curl \
+  -X POST \
+  -H "Authorization: Token <Token>" \
+  -F "url=https://example.com" \
+  -F "preview_image=@/path/to/preview.png" \
+  http://127.0.0.1:8000/api/bookmarks/
 ```
 
 **Update**
@@ -211,6 +228,37 @@ DELETE /api/bookmarks/<id>/
 ```
 
 Deletes a bookmark by ID.
+
+**Upload preview image**
+
+```
+POST /api/bookmarks/<id>/preview-image/
+```
+
+Uploads a custom preview image for a bookmark. Send a `multipart/form-data`
+request with a `file` field that contains the image to upload. The file must
+use one of the supported preview image extensions and stay within the configured
+maximum size (see the `LD_PREVIEW_ALLOWED_EXTENSIONS` and
+`LD_PREVIEW_MAX_SIZE` settings).
+
+Example request using `curl`:
+
+```
+curl \
+  -X POST \
+  -H "Authorization: Token <Token>" \
+  -F "file=@/path/to/preview.png" \
+  http://127.0.0.1:8000/api/bookmarks/1/preview-image/
+```
+
+Example response:
+
+```json
+{
+  "message": "Preview image uploaded successfully.",
+  "preview_image_url": "http://127.0.0.1:8000/static/0ac5c53db923727765216a3a58e70522.png"
+}
+```
 
 ### Bookmark Assets
 


### PR DESCRIPTION
## Summary
- allow POST /api/bookmarks/ requests to accept a preview image upload alongside bookmark data
- cover the new workflow with API tests that exercise both success and validation failures
- document how to submit multipart bookmark creation requests with preview image files

## Testing
- uv run pytest bookmarks/tests/test_bookmarks_api.py bookmarks/tests/test_bookmarks_api_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0515ca3083309902f8b4595d873e