### PR TITLE
Add support for preview image uploads from external URLs

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -116,16 +116,25 @@ class BookmarkViewSet(
         bookmark = self.get_object()
 
         upload_file = request.FILES.get("file")
-        if not upload_file:
+        image_url = request.data.get("image_url")
+        if isinstance(image_url, str):
+            image_url = image_url.strip() or None
+
+        if not upload_file and not image_url:
             return Response(
-                {"error": "No file provided."},
+                {"error": "Either 'file' or 'image_url' must be provided."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         try:
-            new_preview_image_file = preview_image_loader.save_uploaded_preview_image(
-                upload_file
-            )
+            if upload_file:
+                new_preview_image_file = (
+                    preview_image_loader.save_uploaded_preview_image(upload_file)
+                )
+            else:
+                new_preview_image_file = (
+                    preview_image_loader.save_preview_image_from_url(image_url)
+                )
         except preview_image_loader.PreviewImageUploadError as error:
             return Response(
                 {"error": str(error)},

--- a/bookmarks/services/preview_image_loader.py
+++ b/bookmarks/services/preview_image_loader.py
@@ -3,6 +3,7 @@ import logging
 import mimetypes
 import os.path
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import requests
@@ -30,6 +31,117 @@ class PreviewImageUploadError(Exception):
     pass
 
 
+class PreviewImageDownloadError(Exception):
+    def __init__(
+        self,
+        code: str,
+        *,
+        error: Exception | None = None,
+        details: dict | None = None,
+    ):
+        super().__init__(code)
+        self.code = code
+        self.error = error
+        self.details = details or {}
+
+
+def _map_download_error_to_message(code: str) -> str:
+    if code == "content_length_exceeds_max":
+        return "File exceeds maximum size."
+    if code == "unsupported_content_type":
+        return "Unsupported file type."
+    return "Failed to download image."
+
+
+def _download_preview_image(
+    image_url: str,
+    file_name_generator: Callable[[str], str],
+    *,
+    log_message: str,
+) -> str:
+    _ensure_preview_folder()
+
+    try:
+        with requests.get(image_url, stream=True) as response:
+            if response.status_code < 200 or response.status_code >= 300:
+                raise PreviewImageDownloadError(
+                    "bad_status", details={"status_code": response.status_code}
+                )
+
+            content_length_header = response.headers.get("Content-Length")
+            if not content_length_header:
+                raise PreviewImageDownloadError("missing_content_length")
+
+            try:
+                content_length = int(content_length_header)
+            except (TypeError, ValueError):
+                raise PreviewImageDownloadError("missing_content_length")
+
+            if content_length > settings.LD_PREVIEW_MAX_SIZE:
+                raise PreviewImageDownloadError(
+                    "content_length_exceeds_max",
+                    details={"content_length": content_length},
+                )
+
+            content_type_header = response.headers.get("Content-Type")
+            if not content_type_header:
+                raise PreviewImageDownloadError("missing_content_type")
+
+            content_type = content_type_header.split(";", 1)[0]
+            file_extension = mimetypes.guess_extension(content_type)
+
+            if not file_extension or file_extension not in settings.LD_PREVIEW_ALLOWED_EXTENSIONS:
+                raise PreviewImageDownloadError(
+                    "unsupported_content_type",
+                    details={"content_type": content_type},
+                )
+
+            preview_image_file = file_name_generator(file_extension)
+            preview_image_path = _get_image_path(preview_image_file)
+
+            bytes_written = 0
+
+            try:
+                with open(preview_image_path, "wb") as file:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if not chunk:
+                            continue
+
+                        bytes_written += len(chunk)
+                        if bytes_written > settings.LD_PREVIEW_MAX_SIZE:
+                            raise PreviewImageDownloadError(
+                                "content_length_exceeds_max",
+                                details={"content_length": bytes_written},
+                            )
+                        if bytes_written > content_length:
+                            raise PreviewImageDownloadError(
+                                "content_length_mismatch",
+                                details={
+                                    "content_length": content_length,
+                                    "downloaded": bytes_written,
+                                },
+                            )
+
+                        file.write(chunk)
+            except PreviewImageDownloadError:
+                if preview_image_path.exists():
+                    preview_image_path.unlink()
+                raise
+            except Exception:
+                if preview_image_path.exists():
+                    preview_image_path.unlink()
+                raise
+
+    except PreviewImageDownloadError:
+        raise
+    except Exception as error:
+        raise PreviewImageDownloadError("request_error", error=error) from error
+
+    logger.debug(log_message.format(preview_image_path))
+
+    return preview_image_file
+
+
 def load_preview_image(url: str) -> str | None:
     _ensure_preview_folder()
 
@@ -41,58 +153,49 @@ def load_preview_image(url: str) -> str | None:
     image_url = metadata.preview_image
 
     logger.debug(f"Loading preview image: {image_url}")
-    with requests.get(image_url, stream=True) as response:
-        if response.status_code < 200 or response.status_code >= 300:
-            logger.debug(
-                f"Bad response status code for preview image: {image_url} status_code={response.status_code}"
-            )
-            return None
 
-        if "Content-Length" not in response.headers:
+    try:
+        return _download_preview_image(
+            image_url,
+            lambda extension: f"{_url_to_filename(url)}{extension}",
+            log_message="Saved preview image as: {}",
+        )
+    except PreviewImageDownloadError as error:
+        if error.code == "bad_status":
+            logger.debug(
+                "Bad response status code for preview image: %s status_code=%s",
+                image_url,
+                error.details.get("status_code"),
+            )
+        elif error.code == "missing_content_length":
             logger.debug(f"Empty Content-Length for preview image: {image_url}")
-            return None
-
-        content_length = int(response.headers["Content-Length"])
-        if content_length > settings.LD_PREVIEW_MAX_SIZE:
+        elif error.code == "content_length_exceeds_max":
             logger.debug(
-                f"Content-Length exceeds LD_PREVIEW_MAX_SIZE: {image_url} length={content_length}"
+                "Content-Length exceeds LD_PREVIEW_MAX_SIZE: %s length=%s",
+                image_url,
+                error.details.get("content_length"),
             )
-            return None
-
-        if "Content-Type" not in response.headers:
+        elif error.code == "missing_content_type":
             logger.debug(f"Empty Content-Type for preview image: {image_url}")
-            return None
-
-        content_type = response.headers["Content-Type"].split(";", 1)[0]
-        file_extension = mimetypes.guess_extension(content_type)
-
-        if file_extension not in settings.LD_PREVIEW_ALLOWED_EXTENSIONS:
+        elif error.code == "unsupported_content_type":
             logger.debug(
-                f"Unsupported Content-Type for preview image: {image_url} content_type={content_type}"
+                "Unsupported Content-Type for preview image: %s content_type=%s",
+                image_url,
+                error.details.get("content_type"),
             )
-            return None
-
-        preview_image_hash = _url_to_filename(url)
-        preview_image_file = f"{preview_image_hash}{file_extension}"
-        preview_image_path = _get_image_path(preview_image_file)
-
-        with open(preview_image_path, "wb") as file:
-            downloaded = 0
-            for chunk in response.iter_content(chunk_size=8192):
-                downloaded += len(chunk)
-                if downloaded > content_length:
-                    logger.debug(
-                        f"Content-Length mismatch for preview image: {image_url} length={content_length} downloaded={downloaded}"
-                    )
-                    file.close()
-                    preview_image_path.unlink()
-                    return None
-
-                file.write(chunk)
-
-    logger.debug(f"Saved preview image as: {preview_image_path}")
-
-    return preview_image_file
+        elif error.code == "content_length_mismatch":
+            logger.debug(
+                "Content-Length mismatch for preview image: %s length=%s downloaded=%s",
+                image_url,
+                error.details.get("content_length"),
+                error.details.get("downloaded"),
+            )
+        elif error.code == "request_error":
+            logger.debug(
+                f"Failed to download preview image: {image_url}",
+                exc_info=error.error,
+            )
+        return None
 
 
 def save_uploaded_preview_image(uploaded_file: UploadedFile) -> str:
@@ -130,3 +233,25 @@ def save_uploaded_preview_image(uploaded_file: UploadedFile) -> str:
     logger.debug(f"Saved uploaded preview image as: {preview_image_path}")
 
     return preview_image_file
+
+
+def save_preview_image_from_url(image_url: str) -> str:
+    if not image_url or not image_url.strip():
+        raise PreviewImageUploadError("No image URL provided.")
+
+    image_url = image_url.strip()
+
+    try:
+        return _download_preview_image(
+            image_url,
+            lambda extension: f"{uuid.uuid4().hex}{extension}",
+            log_message="Saved uploaded preview image as: {}",
+        )
+    except PreviewImageDownloadError as error:
+        message = _map_download_error_to_message(error.code)
+        if error.code == "request_error":
+            logger.debug(
+                f"Failed to download preview image: {image_url}",
+                exc_info=error.error,
+            )
+        raise PreviewImageUploadError(message)

--- a/bookmarks/tests/test_bookmarks_api.py
+++ b/bookmarks/tests/test_bookmarks_api.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 
 import bookmarks.services.bookmarks
 from bookmarks.models import Bookmark, BookmarkSearch, UserProfile
-from bookmarks.services import website_loader
+from bookmarks.services import preview_image_loader, website_loader
 from bookmarks.services.wayback import generate_fallback_webarchive_url
 from bookmarks.services.website_loader import WebsiteMetadata
 from bookmarks.tests.helpers import LinkdingApiTestCase, BookmarkFactoryMixin
@@ -1333,7 +1333,48 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
         self.assertTrue(os.path.exists(new_path))
         self.assertFalse(os.path.exists(old_path))
 
-    def test_upload_preview_image_requires_file(self):
+    def test_upload_preview_image_from_url(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        def save_image(url):
+            file_name = "external.png"
+            path = os.path.join(temp_dir, file_name)
+            with open(path, "wb") as file:
+                file.write(b"external")
+            return file_name
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            with patch(
+                "bookmarks.services.preview_image_loader.save_preview_image_from_url",
+                side_effect=save_image,
+            ) as mock_save:
+                response = self.client.post(
+                    reverse(
+                        "linkding:bookmark-upload-preview-image", args=[bookmark.id]
+                    ),
+                    {"image_url": "https://example.com/image.png"},
+                    format="json",
+                )
+
+        mock_save.assert_called_once_with("https://example.com/image.png")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data["message"], "Preview image uploaded successfully."
+        )
+        self.assertEqual(
+            response.data["preview_image_url"],
+            f"http://testserver/static/external.png",
+        )
+
+        bookmark.refresh_from_db()
+        self.assertEqual(bookmark.preview_image_file, "external.png")
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, "external.png")))
+
+    def test_upload_preview_image_requires_file_or_url(self):
         self.authenticate()
         bookmark = self.setup_bookmark()
         temp_dir = tempfile.mkdtemp()
@@ -1347,7 +1388,33 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
             )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["error"], "No file provided.")
+        self.assertEqual(
+            response.data["error"], "Either 'file' or 'image_url' must be provided."
+        )
+
+    def test_upload_preview_image_from_url_propagates_errors(self):
+        self.authenticate()
+        bookmark = self.setup_bookmark()
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+        with override_settings(LD_PREVIEW_FOLDER=temp_dir):
+            with patch(
+                "bookmarks.services.preview_image_loader.save_preview_image_from_url",
+                side_effect=preview_image_loader.PreviewImageUploadError(
+                    "Failed to download image."
+                ),
+            ):
+                response = self.client.post(
+                    reverse(
+                        "linkding:bookmark-upload-preview-image", args=[bookmark.id]
+                    ),
+                    {"image_url": "https://example.com/image.png"},
+                    format="json",
+                )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "Failed to download image.")
 
     def test_upload_preview_image_rejects_large_files(self):
         self.authenticate()

--- a/bookmarks/tests/test_preview_image_loader.py
+++ b/bookmarks/tests/test_preview_image_loader.py
@@ -20,13 +20,16 @@ class MockStreamingResponse:
         content_type="image/png",
         content_length=None,
         status_code=200,
+        include_content_length=True,
     ):
         self.url = url
         self.chunks = [data]
         self.status_code = status_code
-        if not content_length:
+        if content_length is None:
             content_length = len(data)
-        self.headers = {"Content-Type": content_type, "Content-Length": content_length}
+        self.headers = {"Content-Type": content_type}
+        if include_content_length:
+            self.headers["Content-Length"] = content_length
 
     def iter_content(self, **kwargs):
         return self.chunks
@@ -65,11 +68,17 @@ class PreviewImageLoaderTestCase(TestCase):
         content_type="image/png",
         content_length=len(mock_image_data),
         status_code=200,
+        include_content_length=True,
     ):
         mock_response = mock.Mock()
         mock_response.raw = io.BytesIO(icon_data)
         return MockStreamingResponse(
-            url, icon_data, content_type, content_length, status_code
+            url,
+            icon_data,
+            content_type,
+            content_length,
+            status_code,
+            include_content_length,
         )
 
     def get_image_path(self, filename):
@@ -203,3 +212,74 @@ class PreviewImageLoaderTestCase(TestCase):
 
             self.assertImageExists(file, mock_image_data)
             self.assertEqual("jpg", file.split(".")[-1])
+
+    def test_save_preview_image_from_url(self):
+        with mock.patch("requests.get") as mock_get:
+            mock_get.return_value = self.create_mock_response()
+
+            file = preview_image_loader.save_preview_image_from_url(
+                "https://example.com/image.png"
+            )
+
+            self.assertTrue(file.endswith(".png"))
+            self.assertImageExists(file, mock_image_data)
+
+    def test_save_preview_image_from_url_requires_url(self):
+        with self.assertRaises(preview_image_loader.PreviewImageUploadError) as error:
+            preview_image_loader.save_preview_image_from_url("")
+
+        self.assertEqual(str(error.exception), "No image URL provided.")
+
+    def test_save_preview_image_from_url_rejects_invalid_status(self):
+        with mock.patch("requests.get") as mock_get:
+            mock_get.return_value = self.create_mock_response(status_code=400)
+
+            with self.assertRaises(preview_image_loader.PreviewImageUploadError) as error:
+                preview_image_loader.save_preview_image_from_url(
+                    "https://example.com/image.png"
+                )
+
+        self.assertEqual(str(error.exception), "Failed to download image.")
+        self.assertNoImageExists()
+
+    def test_save_preview_image_from_url_rejects_missing_content_length(self):
+        with mock.patch("requests.get") as mock_get:
+            mock_get.return_value = self.create_mock_response(
+                include_content_length=False
+            )
+
+            with self.assertRaises(preview_image_loader.PreviewImageUploadError) as error:
+                preview_image_loader.save_preview_image_from_url(
+                    "https://example.com/image.png"
+                )
+
+        self.assertEqual(str(error.exception), "Failed to download image.")
+        self.assertNoImageExists()
+
+    def test_save_preview_image_from_url_rejects_large_files(self):
+        with mock.patch("requests.get") as mock_get:
+            mock_get.return_value = self.create_mock_response(
+                content_length=settings.LD_PREVIEW_MAX_SIZE + 1
+            )
+
+            with self.assertRaises(preview_image_loader.PreviewImageUploadError) as error:
+                preview_image_loader.save_preview_image_from_url(
+                    "https://example.com/image.png"
+                )
+
+        self.assertEqual(str(error.exception), "File exceeds maximum size.")
+        self.assertNoImageExists()
+
+    def test_save_preview_image_from_url_rejects_invalid_content_type(self):
+        with mock.patch("requests.get") as mock_get:
+            mock_get.return_value = self.create_mock_response(
+                content_type="text/html"
+            )
+
+            with self.assertRaises(preview_image_loader.PreviewImageUploadError) as error:
+                preview_image_loader.save_preview_image_from_url(
+                    "https://example.com/image.png"
+                )
+
+        self.assertEqual(str(error.exception), "Unsupported file type.")
+        self.assertNoImageExists()

--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -218,11 +218,12 @@ Deletes a bookmark by ID.
 POST /api/bookmarks/<id>/preview-image/
 ```
 
-Uploads a custom preview image for a bookmark. Send a `multipart/form-data`
-request with a `file` field that contains the image to upload. The file must
-use one of the supported preview image extensions and stay within the configured
-maximum size (see the `LD_PREVIEW_ALLOWED_EXTENSIONS` and
-`LD_PREVIEW_MAX_SIZE` settings).
+Uploads a custom preview image for a bookmark. You can either send a
+`multipart/form-data` request with a `file` field that contains the image to
+upload or provide a JSON payload with an `image_url` that points to an external
+image. The uploaded file or downloaded image must use one of the supported
+preview image extensions and stay within the configured maximum size (see the
+`LD_PREVIEW_ALLOWED_EXTENSIONS` and `LD_PREVIEW_MAX_SIZE` settings).
 
 Example request using `curl`:
 
@@ -231,6 +232,17 @@ curl \
   -X POST \
   -H "Authorization: Token <Token>" \
   -F "file=@/path/to/preview.png" \
+  http://127.0.0.1:8000/api/bookmarks/1/preview-image/
+```
+
+Example request with an external URL:
+
+```
+curl \
+  -X POST \
+  -H "Authorization: Token <Token>" \
+  -H "Content-Type: application/json" \
+  -d '{"image_url": "https://example.com/preview.png"}' \
   http://127.0.0.1:8000/api/bookmarks/1/preview-image/
 ```
 


### PR DESCRIPTION
## Summary
- allow the bookmark preview-image API to accept either an uploaded file or an external image URL
- centralize remote preview image downloading with validation and add tests that cover new download paths
- document how to submit preview image URLs via the API and extend API tests for the new workflow

## Testing
- `LD_DISABLE_BACKGROUND_TASKS=1 uv run pytest bookmarks/tests/test_preview_image_loader.py`
- `LD_DISABLE_BACKGROUND_TASKS=1 uv run pytest bookmarks/tests/test_bookmarks_api.py::BookmarksApiTestCase::test_upload_preview_image_from_url`
- `LD_DISABLE_BACKGROUND_TASKS=1 uv run pytest bookmarks/tests/test_bookmarks_api.py::BookmarksApiTestCase::test_upload_preview_image_from_url_propagates_errors`
- `LD_DISABLE_BACKGROUND_TASKS=1 uv run pytest bookmarks/tests/test_bookmarks_api.py::BookmarksApiTestCase::test_upload_preview_image_requires_file_or_url`


------
https://chatgpt.com/codex/tasks/task_e_68dbea873fec8330921472252b4ac54f